### PR TITLE
Switch to `envoy` for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ then in your code:
 ```gleam
 
 import dotenv_gleam
-import gleam/erlang/os // do not forget to add gleam_erlang to the project
+import envoy // do not forget to add envoy to the project
 
 pub fn main() {
   dotenv_gleam.config() // this should load .env file
 
-  let assert Ok(test) = os.get_env("TEST")
-  let assert Ok(bar) = os.get_env("BAR")
-
+  let assert Ok(test) = envoy.get("TEST")
+  let assert Ok(bar) = envoy.get("BAR")
 }
 
 // or you can specify the path to the .env file
@@ -34,8 +33,8 @@ pub fn main() {
 pub fn main() {
   dotenv_gleam.config_with("path/to/.env") // this should load .env file
 
-  let assert Ok(test) = os.get_env("TEST")
-  let assert Ok(bar) = os.get_env("BAR")
+  let assert Ok(test) = envoy.get("TEST")
+  let assert Ok(bar) = envoy.get("BAR")
 }
 
 ```

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dotenv_gleam"
-version = "1.0.6"
+version = "1.0.7"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.

--- a/gleam.toml
+++ b/gleam.toml
@@ -16,6 +16,7 @@ repository = { type = "github", user = "Grubba27", repo = "dotenv_gleam" }
 gleam_stdlib = "~> 0.36"
 gleam_erlang = "~> 0.22"
 simplifile = "~> 2.0"
+envoy = "~> 1.0.2"
 
 [dev-dependencies]
 gleeunit = "~> 1.0.2"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,16 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_erlang", version = "0.24.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "26BDB52E61889F56A291CB34167315780EE4AA20961917314446542C90D1C1A0" },
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
+  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
+  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
   { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
   { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
 ]
 
 [requirements]
+envoy = { version = "~> 1.0.2" }
 gleam_erlang = { version = "~> 0.22" }
 gleam_stdlib = { version = "~> 0.36" }
 gleeunit = { version = "~> 1.0.2" }

--- a/src/dotenv_gleam.gleam
+++ b/src/dotenv_gleam.gleam
@@ -13,7 +13,7 @@ import simplifile
 ///
 /// ```gleam
 /// > config()
-/// > os.get_env("TEST")
+/// > envoy.get("TEST")
 /// "test"
 /// ```
 pub fn config() {
@@ -29,7 +29,7 @@ pub fn config() {
 ///
 /// ```gleam
 /// > config_with("path/to/.env")
-/// > os.get_env("TEST")
+/// > envoy.get("TEST")
 /// "test"
 /// ```
 pub fn config_with(file: String) {

--- a/src/dotenv_gleam.gleam
+++ b/src/dotenv_gleam.gleam
@@ -1,7 +1,7 @@
 import gleam/string
 import gleam/list
 import gleam/result
-import gleam/erlang/os
+import envoy
 import simplifile
 
 /// Tries to load environment variables from a `.env` file in the current
@@ -51,6 +51,6 @@ pub fn config_with(file: String) {
       |> string.join("=")
       |> string.trim()
 
-    os.set_env(key, value)
+    envoy.set(key, value)
   })
 }

--- a/src/dotenv_gleam.gleam
+++ b/src/dotenv_gleam.gleam
@@ -1,7 +1,7 @@
-import gleam/string
+import envoy
 import gleam/list
 import gleam/result
-import envoy
+import gleam/string
 import simplifile
 
 /// Tries to load environment variables from a `.env` file in the current

--- a/test/dotenv_gleam_test.gleam
+++ b/test/dotenv_gleam_test.gleam
@@ -1,7 +1,7 @@
+import dotenv_gleam
+import envoy
 import gleeunit
 import gleeunit/should
-import envoy
-import dotenv_gleam
 
 pub fn main() {
   gleeunit.main()

--- a/test/dotenv_gleam_test.gleam
+++ b/test/dotenv_gleam_test.gleam
@@ -1,6 +1,6 @@
 import gleeunit
 import gleeunit/should
-import gleam/erlang/os
+import envoy
 import dotenv_gleam
 
 pub fn main() {
@@ -8,11 +8,11 @@ pub fn main() {
 }
 
 fn check() {
-  let assert Ok(test_) = os.get_env("TEST")
-  let assert Ok(bar) = os.get_env("BAR")
-  let assert Ok(ops) = os.get_env("OPS")
-  let assert Ok(k) = os.get_env("K")
-  let assert Ok(uri) = os.get_env("SOME_HARDURI")
+  let assert Ok(test_) = envoy.get("TEST")
+  let assert Ok(bar) = envoy.get("BAR")
+  let assert Ok(ops) = envoy.get("OPS")
+  let assert Ok(k) = envoy.get("K")
+  let assert Ok(uri) = envoy.get("SOME_HARDURI")
 
   should.equal(test_, "FOO")
   should.equal(bar, "BAR")


### PR DESCRIPTION
`gleam_erlang` 0.33 removed the environment modification functions.
This PR switches to `envoy` as the `gleam_erlang` changelog suggests.