### PR TITLE
Return `Result` instead of using `assert` internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import dotenv_gleam
 import envoy // do not forget to add envoy to the project
 
 pub fn main() {
-  dotenv_gleam.config() // this should load .env file
+  let assert Ok(Nil) = dotenv_gleam.config() // this should load .env file or return an error if it does not exist
 
   let assert Ok(test) = envoy.get("TEST")
   let assert Ok(bar) = envoy.get("BAR")
@@ -31,7 +31,7 @@ pub fn main() {
 // or you can specify the path to the .env file
 
 pub fn main() {
-  dotenv_gleam.config_with("path/to/.env") // this should load .env file
+  let assert Ok(Nil) = dotenv_gleam.config_with("path/to/.env") // this should load .env file or return an error if it does not exist
 
   let assert Ok(test) = envoy.get("TEST")
   let assert Ok(bar) = envoy.get("BAR")

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "dotenv_gleam"
-version = "1.0.7"
+version = "2.0.0"
 
 # Fill out these fields if you intend to generate HTML documentation or publish
 # your project to the Hex package manager.

--- a/test/dotenv_gleam_test.gleam
+++ b/test/dotenv_gleam_test.gleam
@@ -26,11 +26,15 @@ fn check() {
 
 // gleeunit test functions end in `_test`
 pub fn should_set_env_from_file_test() {
-  dotenv_gleam.config()
+  let _ = dotenv_gleam.config()
   check()
 }
 
 pub fn should_set_env_from_file_selected_test() {
-  dotenv_gleam.config_with(".env.test")
+  let _ = dotenv_gleam.config_with(".env.test")
   check()
+}
+
+pub fn should_return_error_when_file_not_found_test() {
+  let assert Error(_) = dotenv_gleam.config_with(".env.notfound")
 }


### PR DESCRIPTION
Closes: #10 

This PR changes the return type of the functions `config` and `config_with` to return `Result(Nil, DotEnvError)` instead of using `assert` internally.

As the issue states, returning a `Result` is better because it gives the user more control over handling cases where the file can't be read.
Besides that, it's common for `.env` files to only exist in the development environment and not in production. With the current implementation, we don't support those cases and the developer has to do some logic to call `dotenv_gleam.config()` conditionally or something around that, which is not ideal. Returning a `Result` also solves this because the developer can simply ignore the return of `dotenv_gleam.config` and validate if the environment variable exists (after all, this is what matters)

_Note: I've bumped the version of the package to 2.0.0 since this is a breaking change_