### PR TITLE
Bump dependency versions to support current gleam version

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -6,17 +6,15 @@ version = "2.0.0"
 #
 description = "dotenv for Gleam"
 licences = ["MIT"]
-links = [
-  {title = "gleam", href = "https://gleam.run"}
-]
+links = [{ title = "gleam", href = "https://gleam.run" }]
 repository = { type = "github", user = "Grubba27", repo = "dotenv_gleam" }
 
 
 [dependencies]
 gleam_stdlib = "~> 0.36"
-gleam_erlang = "~> 0.22"
+gleam_erlang = "~> 1.0"
 simplifile = "~> 2.0"
 envoy = "~> 1.0.2"
 
 [dev-dependencies]
-gleeunit = "~> 1.0.2"
+gleeunit = "~> 1.2"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,16 +3,16 @@
 
 packages = [
   { name = "envoy", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "envoy", source = "hex", outer_checksum = "95FD059345AA982E89A0B6E2A3BF1CF43E17A7048DCD85B5B65D3B9E4E39D359" },
-  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
-  { name = "gleam_erlang", version = "0.33.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "A1D26B80F01901B59AABEE3475DD4C18D27D58FA5C897D922FCB9B099749C064" },
-  { name = "gleam_stdlib", version = "0.51.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "14AFA8D3DDD7045203D422715DBB822D1725992A31DF35A08D97389014B74B68" },
-  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
-  { name = "simplifile", version = "2.2.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0DFABEF7DC7A9E2FF4BB27B108034E60C81BEBFCB7AB816B9E7E18ED4503ACD8" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "0.65.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "7C69C71D8C493AE11A5184828A77110EB05A7786EBF8B25B36A72F879C3EE107" },
+  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
+  { name = "simplifile", version = "2.3.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "0A868DAC6063D9E983477981839810DC2E553285AB4588B87E3E9C96A7FB4CB4" },
 ]
 
 [requirements]
 envoy = { version = "~> 1.0.2" }
-gleam_erlang = { version = "~> 0.22" }
+gleam_erlang = { version = "~> 1.0" }
 gleam_stdlib = { version = "~> 0.36" }
-gleeunit = { version = "~> 1.0.2" }
+gleeunit = { version = "~> 1.2" }
 simplifile = { version = "~> 2.0" }


### PR DESCRIPTION
This is supposed to fix #12.

Tried to keep the changes in the dependency versions as low as possible. 

Builds fine, tests run ok.